### PR TITLE
Исправление бага

### DIFF
--- a/application/modules/imagebox/admin.php
+++ b/application/modules/imagebox/admin.php
@@ -108,7 +108,7 @@ class Admin extends MY_Controller {
             
             $this->load->library('upload', $config);
         
-            if ( ! $this->upload->do_upload())
+            if ( ! $this->upload->do_upload('userfile'))
             {
                 echo 'Error: '. $this->upload->display_errors('', '');
                 return;

--- a/application/modules/imagebox/templates/main_window.tpl
+++ b/application/modules/imagebox/templates/main_window.tpl
@@ -4,7 +4,7 @@
 <div>
     <form id="image_upload_form" style="width:100%;" method="post" enctype="multipart/form-data" action="{site_url('admin/components/run/imagebox/upload')}">
         <div class="form_text">Выберите файл:</div>
-        <div class="form_input"><input type="file" name="userfile" id="file" size="30" /></div>
+        <div class="form_input"><input type="file" name="userfile[]" id="file" size="30" /></div>
         <div class="form_overflow"></div>
 
         <div class="form_text">Или укажите URL</div>


### PR DESCRIPTION
Баг есть в версии без магазина.

Как воспроизвести:
В окне imagebox main_window выбираем файл, нажимаем отправить и получаем... сообщение «Error: Файл не выбран».

Этот баг возникает из-за того, что либа CI Upload требует не просто _FILES с одним файлом, а именно массив, пусть даже и из одного элемента.

Необходимо потестировать — возможно это зависит от браузера?
