### PR TITLE
libraries/cache.php - BugFix

### DIFF
--- a/application/libraries/cache.php
+++ b/application/libraries/cache.php
@@ -310,40 +310,44 @@ class Cache {
      * @access public
      */
     public function delete_all() {
-        if ($handle = opendir($this->_Config['store'])) {
-            $n = 0;
-
-            while (false !== ($file = readdir($handle))) {
+        $n = 0;
+        
+        $cache_store_dir = $this->_Config['store'] . "/";
+        if (is_dir($cache_store_dir) and ($root_dir_handle = opendir($cache_store_dir))) {
+            while (false !== ($file = readdir($root_dir_handle))) {
+            
                 if (substr($file, 0, 6) != 'cache_' && $file != 'hooks.php' && $file != "." && $file != ".." && $file != "/" && strstr($file, '.') != TRUE) {
 
-                    $files_all = opendir("./system/cache/" . $file);
-                    while (false !== ($fileT = readdir($files_all))) {
-                        if ($fileT != "." && $fileT != ".." && $fileT != "/") {
-                            $n++;
-                            @unlink("./system/cache/" . $file . "/" . $fileT);
+                    $cache_sub_dir = $cache_store_dir . $file . "/";
+                    if (is_dir($cache_sub_dir) and ($sub_dir_handle = opendir($cache_sub_dir))) {
+                        while (false !== ($fileT = readdir($sub_dir_handle))) {
+                        
+                            if ($fileT != "." && $fileT != ".." && $fileT != "/") {
+                            
+                                $n++;
+                                @unlink($cache_sub_dir . $fileT);
+                            }
                         }
                     }
                 }
                 if (substr($file, 0, 6) == 'cache_' || $file == 'hooks.php' || strstr($file, '.') === TRUE) {
 
-                    if (substr($file, 0, 6) === 'cache_' || strstr($file, '.') == TRUE) {
-
-                        $n++;
-                    }
-                    @unlink("./system/cache/" . $file);
+                    $n++;
+                    @unlink($cache_store_dir . $file);
                 }
             }
         }
 
-        $files_all = opendir("./system/cache/templates_c/HTML");
-        
-        while (false !== ($fileT = readdir($files_all)))
-            if ($fileT != "." && $fileT != ".." && $fileT != "/"){
-                //echo $files_all . "/" . $fileT . '<br/>';
-                @unlink('./system/cache/templates_c/HTML/' . $fileT);
+        $cache_sub_dir = $cache_store_dir . "templates_c/HTML/";
+        if (is_dir($cache_sub_dir) and ($sub_dir_handle = opendir($cache_sub_dir))) {
+            while (false !== ($fileT = readdir($sub_dir_handle))) {
+            
+                if ($fileT != "." && $fileT != ".." && $fileT != "/"){
+                
+                    @unlink($cache_sub_dir . $fileT);
+                }
             }
-
-
+        }
 
 
         $this->log_cache_error('All cache files deleted');
@@ -372,16 +376,21 @@ class Cache {
     }
 
     public function cache_file() {
-        if ($handle = opendir($this->_Config['store'])) {
-            $n = 0;
-
-            while (false !== ($file = readdir($handle))) {
+        $n = 0;
+        
+        $cache_store_dir = $this->_Config['store'] . "/";
+        if (is_dir($cache_store_dir) and ($root_dir_handle = opendir($cache_store_dir))) {
+            while (false !== ($file = readdir($root_dir_handle))) {
+            
                 if (substr($file, 0, 6) != 'cache_' && $file != 'hooks.php' && $file != "." && $file != ".." && $file != "/" && strstr($file, '.') != TRUE) {
 
-                    $files_all = opendir("./system/cache/" . $file);
-                    while (false !== ($fileT = readdir($files_all))) {
-                        if ($fileT != "." && $fileT != ".." && $fileT != "/" && strstr($fileT, '~') != TRUE) {
-                            $n++;
+                    $cache_sub_dir = $cache_store_dir . $file . "/";
+                    if (is_dir($cache_sub_dir) and ($sub_dir_handle = opendir($cache_sub_dir))) {
+                        while (false !== ($fileT = readdir($sub_dir_handle))) {
+                        
+                            if ($fileT != "." && $fileT != ".." && $fileT != "/" && strstr($fileT, '~') != TRUE) {
+                                $n++;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
application/libraries/cache.php

Выдержка из комментария для этого фикса на собственном проекте:

> //
> Исправлен баг с подвисанием при вызове методов cache->cache_file (подсчет количества файлов в кэше) и cache->delete_all (удаление всех файлов из кэша);
> проблема замечена при:
> - добавлении/сохранении публикации
> - сохранении категории
> - сохранении глобальных настроек
> - загрузке страницы кэша (меню Система -> Кэш)
> 
> Причина оказалась в том, что внутри указанных методов php-функция readdir по ошибке вызывалась кроме каталогов еще и на некоторых файлах. Неправильно было составлено условие отсева файлов - просачивались те, у которых в имени не было точки и префикса "cache_". На дескрипторах файлов функция readdir возвращала NULL, а в условии цикла while было точное сравнение на идентичность: (false !== ($file = readdir($handle))), из-за чего возникало зацикливание.
> 
> Также не была реализована стандартная проверка имени на каталог (php-функция is_dir) и на валидность возвращенного php-функцией opendir дескриптора объекта файловой системы.
> 
> Решение: везде перед началом пробега по каталогу (readdir) добавлены проверка пути на каталог (is_dir) и проверка на валидность полученного дескриптора.
> //

Изначально баг заявлен в теме:
http://forum.imagecms.net/viewtopic.php?id=2595
