### PR TITLE
Fix bugs

### DIFF
--- a/application/modules/gallery/admin.php
+++ b/application/modules/gallery/admin.php
@@ -807,7 +807,11 @@ class Admin extends BaseAdminController {
                     $this->resize_and_thumb($data[$i]['upload_data']);
                     $this->add_image($album_id, $data[$i]['upload_data']);
                 }
-                $this->conf = $temp_conf;
+                $buf = $this->conf['upload_path'];
+
+				$this->conf = $temp_conf;
+				$this->conf['upload_path'] = $buf;
+				
                 $i++;
             }
 

--- a/system/core/Output.php
+++ b/system/core/Output.php
@@ -96,11 +96,11 @@ class CI_Output {
 		// Get mime types for later
 		if (defined('ENVIRONMENT') AND file_exists(APPPATH.'config/'.ENVIRONMENT.'/mimes.php'))
 		{
-		    include APPPATH.'config/'.ENVIRONMENT.'/mimes.php';
+			$mimes = include APPPATH.'config/'.ENVIRONMENT.'/mimes.php';
 		}
 		else
 		{
-			include APPPATH.'config/mimes.php';
+			$mimes = include APPPATH.'config/mimes.php';
 		}
 
 


### PR DESCRIPTION
I) Ошибка конфига mime-types
Переменная $mimes не определяется, что вызывает нотис, и неправильную работу с Content-Type вообще во всем проекте. Предполагаю что код должен бы выглядеть как в пул реквесте.

Но! Среди конфигов есть файл "mimes_old.php", который как раз объявляет эту переменную, а не делает return как "mime.php". 

Вобщем вариантов два:
1) Сделать так как предложил я, но это как я понимаю правки в самом фреймворке, что может быть не желательным
2) Подправить конфиг mimes чтобы он выглядел как mimes_old

II) Ошибка создания превьюшек в галерее
При добавлении нескольких изображений превьюшка создается только для первой из них. Решение проблемы нашел на вашем форуме.
