### PR TITLE
Update core_widgets.php

### DIFF
--- a/application/modules/core/core_widgets.php
+++ b/application/modules/core/core_widgets.php
@@ -56,7 +56,7 @@ class Core_Widgets extends MY_Controller {
 
                 // Truncate text
                 if ($settings['max_symdols'] > 0 AND mb_strlen($news[$i]['prev_text'], 'utf-8') > $settings['max_symdols']) {
-                    $news[$i]['prev_text'] = strip_tags(mb_substr($news[$i]['prev_text'], 0, $settings['max_symdols'], 'utf-8')) . '...';
+                    $news[$i]['prev_text'] = mb_substr(strip_tags($news[$i]['prev_text'], 0, $settings['max_symdols'], 'utf-8')) . '...';
                 }
             }
 


### PR DESCRIPTION
Мне кажется рациональнее будет сначала удалить все теги из prev_text, а потом уже обрезать длину. В этом случае мы получим точное количество символов, указанных в настройках. В данный момент сначала строка с тегами обрезается до нужного количества символов, а потом удаляются теги, в итоге от 150 символов могут остаться всего 30...
